### PR TITLE
Adds SailorConsumer Widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -95,6 +95,12 @@ class Home extends StatelessWidget {
               },
             ),
             RaisedButton(
+              child: Text('Navigate to SailorConsumerPage'),
+              onPressed: () async {
+                Routes.sailor.navigate("/sailorConsumerPage", args: ThirdPageArgs(1));
+              },
+            ),
+            RaisedButton(
               child: Text('Print navigation stack!'),
               onPressed: () {
                 Routes.sailor.navigationStackObserver.prettyPrintStack();
@@ -183,6 +189,22 @@ class ThirdPage extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class PageWithSailorConsumer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SailorConsumer<ThirdPageArgs>(
+      builder: (context, ThirdPageArgs arg) {
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('Using SailorConsumer'),
+          ),
+          body: Text('Count arg: ${arg.count}'),
+        );
+      },
     );
   }
 }
@@ -286,6 +308,10 @@ class Routes {
             )
           ],
         ),
+        SailorRoute(
+          name: '/sailorConsumerPage',
+          builder: (context, args, params) => PageWithSailorConsumer(),
+        )
       ],
     );
   }

--- a/lib/src/sailor.dart
+++ b/lib/src/sailor.dart
@@ -16,6 +16,8 @@ import 'package:sailor/src/transitions/transition_factory.dart';
 import 'package:sailor/src/ui/page_not_found.dart';
 import 'models/route_args_pair.dart';
 
+typedef SailorConsumerBuilder<T extends BaseArguments> = Widget Function(BuildContext context, T arguments);
+
 enum NavigationType { push, pushReplace, pushAndRemoveUntil, popAndPushNamed }
 
 /// Sailor manages routing, registering routes with transitions, navigating to
@@ -567,5 +569,18 @@ class ParamMap {
     final defaultParamValue = _routeParams[key].defaultValue;
     final paramFromNavigationCall = _params != null ? _params[key] : null;
     return (paramFromNavigationCall ?? defaultParamValue) as T;
+  }
+}
+
+class SailorConsumer<T extends BaseArguments> extends StatelessWidget {
+  final SailorConsumerBuilder<T> builder;
+
+  SailorConsumer({this.builder});
+
+  @override
+  Widget build(BuildContext context) {
+    final args = Sailor.args<T>(context);
+
+    return builder(context, args);
   }
 }


### PR DESCRIPTION
This PR is a MVP of #10, which will allow users to use SailorConsumer as a Builder

Example
```dart
class PageWithSailorConsumer extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return SailorConsumer<ThirdPageArgs>(
      builder: (context, ThirdPageArgs arg) {
        return Scaffold(
          appBar: AppBar(
            title: Text('Using SailorConsumer'),
          ),
          body: Text('Count arg: ${arg.count}'),
        );
      },
    );
  }
}
```
![Simulator Screen Shot - iPhone X - 2019-12-02 at 10 29 34](https://user-images.githubusercontent.com/10780132/69963326-c3ebbd80-14ee-11ea-9762-1cf7eda26e56.png)

I also added this to example folder
 