### PR TITLE
Pop now returns void

### DIFF
--- a/lib/src/sailor.dart
+++ b/lib/src/sailor.dart
@@ -425,8 +425,8 @@ class Sailor {
   }
 
   /// Delegation for [Navigator.pop].
-  bool pop([dynamic result]) {
-    return this.navigatorKey.currentState.pop(result);
+  void pop([dynamic result]) {
+    this.navigatorKey.currentState.pop(result);
   }
 
   /// Delegation for [Navigator.popUntil].


### PR DESCRIPTION
Fix issue https://github.com/gurleensethi/sailor/issues/26
`pop` function will return void in future versions of Flutter