### PR TITLE
fixed Can't return a value from a void function bug on master and stable channel

### DIFF
--- a/lib/src/sailor.dart
+++ b/lib/src/sailor.dart
@@ -426,7 +426,7 @@ class Sailor {
 
   /// Delegation for [Navigator.pop].
   void pop([dynamic result]) {
-    return this.navigatorKey.currentState.pop(result);
+    this.navigatorKey.currentState.pop(result);
   }
 
   /// Delegation for [Navigator.popUntil].


### PR DESCRIPTION
fixed the bug for master and stable channel which prevents flutter from build and keeps complaining of Can't return a value from a void function.